### PR TITLE
Level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 
 
+test.db/

--- a/lib/database.js
+++ b/lib/database.js
@@ -177,7 +177,7 @@ Database.prototype.dropCollection = function dropCollection(collectionName, rela
                 .on('end', function(){
                     deferred.resolve();
                 })
-                .on('error', function(){
+                .on('error', function(err){
                     deferred.reject(err);
                 });
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,7 +1,7 @@
 /**
  * Created by mbinot on 08.05.14.
  */
-var LevelUp = require('levelup');
+var level = require('level');
 var Errors = require('waterline-errors');
 var WaterlineCriteria = require('waterline-criteria');
 var Schema = require('./schema');
@@ -52,7 +52,7 @@ Database.prototype.initialize = function (registeredClients, cb) {
 
             descriptor = {
                 counter: 1,
-                client: Promise.promisifyAll(LevelUp(self.connection.database, self.connection.options))
+                client: Promise.promisifyAll(level(self.connection.database, self.connection.options))
             };
             registeredClients[self.clientIdentifier] = descriptor;
             self.connection.client = descriptor.client;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "test": "node test/integration/runner -R spec -b"
   },
-  "repository": {"type":"git","url":"git://github.com/balderdashy/waterline-%s.git"},
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/balderdashy/waterline-%s.git"
+  },
   "keywords": [
     "leveldb",
     "adapter",
@@ -19,13 +22,12 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-      "lodash": "~2.4.1",
-      "levelup" : "~0.18.3",
-      "leveldown" : "~0.10.2",
-      "async" : "~0.8.0",
-      "bluebird" : "~1.2.4",
-      "waterline-errors": "~0.10.0",
-      "waterline-criteria": "~0.10.2"
+    "async": "~0.8.0",
+    "bluebird": "~1.2.4",
+    "level": "~0.18.0",
+    "lodash": "~2.4.1",
+    "waterline-criteria": "~0.10.2",
+    "waterline-errors": "~0.10.0"
   },
   "devDependencies": {
     "waterline-adapter-tests": "~0.10.0",


### PR DESCRIPTION
Use `level` instead of explicitly using `levelup` and `leveldown`. `level` is a convenience module that will ensure they come bundled correctly.

/cc @tjwebb
